### PR TITLE
Handle one double quotes in DOCTYPE

### DIFF
--- a/src/java/org/ccil/cowan/tagsoup/Parser.java
+++ b/src/java/org/ccil/cowan/tagsoup/Parser.java
@@ -875,6 +875,7 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
 		if (in == null) return in;
 		int length = in.length();
 		if (length == 0) return in;
+		if (s == '"') return in;
 		char s = in.charAt(0);
 		char e = in.charAt(length - 1);
 		if (s == e && (s == '\'' || s == '"')) {

--- a/src/java/org/ccil/cowan/tagsoup/Parser.java
+++ b/src/java/org/ccil/cowan/tagsoup/Parser.java
@@ -875,9 +875,9 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
 		if (in == null) return in;
 		int length = in.length();
 		if (length == 0) return in;
-		if (s == '"') return in;
 		char s = in.charAt(0);
 		char e = in.charAt(length - 1);
+		if (length == 1 && s == '"') return in;
 		if (s == e && (s == '\'' || s == '"')) {
 			in = in.substring(1, in.length() - 1);
 			}


### PR DESCRIPTION
trimquotes() is not able to handle following case where there is only one double quotes in element
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0  Transitional//EN" ">
StringIndexOutOfBoundsException thrown now